### PR TITLE
dropped cleancss, in favour of "the-minifier"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 bun.lockb
 yarn.lock
 *.min*
+tests

--- a/extension.js
+++ b/extension.js
@@ -7,15 +7,15 @@ const path = require('path');
 
 const { minify: minifyHTML } = require('html-minifier-terser');
 const { minify: minifyJS } = require('terser');
-
+const minifyCSS = require('clean-css');
 const { cssFormatter } = require('the-minifier');
-
 
 let onlyMinUnderSubFolder = "";
 
 let enableHTMLMinification = true;
 let enableJSMinification = true;
 let enableCSSMinification = true;
+let cssLegacyMinifier = false;
 
 let enableSeparateFolderHTML = false;
 let enableSeparateFolderJS = false;
@@ -24,7 +24,6 @@ let enableSeparateFolderCSS = false;
 let enableShowInPreviewOnly = false;
 
 let currentPanel;
-
 
 let htmlMinifierOptions = {
 	removeAttributeQuotes: true,
@@ -46,6 +45,13 @@ let htmlMinifierOptions = {
 	html5: true
 };
 
+let cssMinifierOptions = {
+	level: {
+		1: {
+			all: true
+		}
+	}
+};
 
 let jsMinifierOptions = {
 	mangle: false
@@ -120,6 +126,7 @@ function activate(context) {
 			event.affectsConfiguration('autominify.enableHTMLMinification') ||
 			event.affectsConfiguration('autominify.enableJSMinification') ||
 			event.affectsConfiguration('autominify.enableCSSMinification') ||
+			event.affectsConfiguration('autominify.cssLegacyMinifier') ||
 
 			event.affectsConfiguration('autominify.enableSeparateFolderHTML') ||
 			event.affectsConfiguration('autominify.enableSeparateFolderJS') ||
@@ -127,6 +134,7 @@ function activate(context) {
 
 			event.affectsConfiguration('autominify.enableShowInPreviewOnly') ||
 			event.affectsConfiguration('autominify.htmlMinifierOptions') ||
+			event.affectsConfiguration('autominify.cssMinifierOptions') ||
 			event.affectsConfiguration('autominify.jsMinifierOptions')
 		) {
 			updateSettings();
@@ -142,7 +150,8 @@ function activate(context) {
 	}
 
 	async function minifyCSSContent(inputFile) {
-		return cssFormatter(inputFile);
+		if (cssLegacyMinifier) return cssFormatter(inputFile);
+		else return (new minifyCSS(cssMinifierOptions).minify(inputFile)).styles;
 	}
 
 	async function writeFile(outputPath, content) {
@@ -235,12 +244,14 @@ function updateSettings() {
 	enableHTMLMinification = config.get('enableHTMLMinification', true);
 	enableJSMinification = config.get('enableJSMinification', true);
 	enableCSSMinification = config.get('enableCSSMinification', true);
+	cssLegacyMinifier = config.get('cssLegacyMinifier', true);
 
 	enableSeparateFolderHTML = config.get('enableSeparateFolderHTML', false);
 	enableSeparateFolderJS = config.get('enableSeparateFolderJS', false);
 	enableSeparateFolderCSS = config.get('enableSeparateFolderCSS', false);
 
 	htmlMinifierOptions = config.get('htmlMinifierOptions', htmlMinifierOptions);
+	cssMinifierOptions = config.get('cssMinifierOptions', cssMinifierOptions);
 	jsMinifierOptions = config.get('jsMinifierOptions', jsMinifierOptions);
 }
 

--- a/extension.js
+++ b/extension.js
@@ -7,7 +7,9 @@ const path = require('path');
 
 const { minify: minifyHTML } = require('html-minifier-terser');
 const { minify: minifyJS } = require('terser');
-const minifyCSS = require('clean-css');
+
+const { cssFormatter } = require('the-minifier');
+
 
 let onlyMinUnderSubFolder = "";
 
@@ -22,6 +24,7 @@ let enableSeparateFolderCSS = false;
 let enableShowInPreviewOnly = false;
 
 let currentPanel;
+
 
 let htmlMinifierOptions = {
 	removeAttributeQuotes: true,
@@ -43,13 +46,6 @@ let htmlMinifierOptions = {
 	html5: true
 };
 
-let cssMinifierOptions = {
-	level: {
-		1: {
-			all: true
-		}
-	}
-};
 
 let jsMinifierOptions = {
 	mangle: false
@@ -131,7 +127,6 @@ function activate(context) {
 
 			event.affectsConfiguration('autominify.enableShowInPreviewOnly') ||
 			event.affectsConfiguration('autominify.htmlMinifierOptions') ||
-			event.affectsConfiguration('autominify.cssMinifierOptions') ||
 			event.affectsConfiguration('autominify.jsMinifierOptions')
 		) {
 			updateSettings();
@@ -147,8 +142,7 @@ function activate(context) {
 	}
 
 	async function minifyCSSContent(inputFile) {
-		const minifiedCSS = new minifyCSS(cssMinifierOptions).minify(inputFile);
-		return minifiedCSS.styles;
+		return cssFormatter(inputFile);
 	}
 
 	async function writeFile(outputPath, content) {
@@ -247,7 +241,6 @@ function updateSettings() {
 	enableSeparateFolderCSS = config.get('enableSeparateFolderCSS', false);
 
 	htmlMinifierOptions = config.get('htmlMinifierOptions', htmlMinifierOptions);
-	cssMinifierOptions = config.get('cssMinifierOptions', cssMinifierOptions);
 	jsMinifierOptions = config.get('jsMinifierOptions', jsMinifierOptions);
 }
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "autominify",
   "displayName": "Auto-Minify",
   "description": "Automatically minify your HTML, CSS, and JS files on save",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "repository": "https://github.com/caffeineonice/autominify",
   "license": "MIT",
   "icon": "icon.png",
@@ -89,6 +89,22 @@
           },
           "description": "HTML Minifier options"
         },
+        "autominify.cssMinifierOptions": {
+          "type": "object",
+          "default": {
+            "level": {
+              "1": {
+                "all": true
+              }
+            }
+          },
+          "description": "Clean-CSS options"
+        },
+        "autominify.cssLegacyMinifier": {
+          "type": "boolean",
+          "default": false,
+          "description": "LegacyMinifier"
+        },
         "autominify.jsMinifierOptions": {
           "type": "object",
           "default": {
@@ -100,6 +116,7 @@
     }
   },
   "dependencies": {
+    "clean-css": "^5.3.3",
     "html-minifier-terser": "^7.2.0",
     "terser": "^5.26.0",
     "the-minifier": "^1.2.2"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "autominify",
   "displayName": "Auto-Minify",
   "description": "Automatically minify your HTML, CSS, and JS files on save",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": "https://github.com/caffeineonice/autominify",
   "license": "MIT",
   "icon": "icon.png",
@@ -89,17 +89,6 @@
           },
           "description": "HTML Minifier options"
         },
-        "autominify.cssMinifierOptions": {
-          "type": "object",
-          "default": {
-            "level": {
-              "1": {
-                "all": true
-              }
-            }
-          },
-          "description": "Clean-CSS options"
-        },
         "autominify.jsMinifierOptions": {
           "type": "object",
           "default": {
@@ -111,17 +100,17 @@
     }
   },
   "dependencies": {
-    "clean-css": "^5.3.3",
     "html-minifier-terser": "^7.2.0",
-    "terser": "^5.26.0"
+    "terser": "^5.26.0",
+    "the-minifier": "^1.2.2"
   },
   "devDependencies": {
+    "3": "^2.1.0",
     "@types/node": "^14.14.41",
     "@types/vscode": "^1.85.0",
-    "@vscode/vsce": "^2.22.0",
-    "mocha": "^10.3.0",
     "@vscode/test-electron": "^2.3.9",
-    "3": "^2.1.0"
+    "@vscode/vsce": "^2.22.0",
+    "mocha": "^10.3.0"
   },
   "engines": {
     "vscode": "^1.85.0"


### PR DESCRIPTION
Fix for https://github.com/CaffeineOnIce/AutoMinify/issues/14

    const minifyCSS = require('clean-css');

becomes

    const { cssFormatter } = require('the-minifier');

✅ Updated version number
✅ Test passed


----

[csso](https://www.npmjs.com/package/csso) had issues
[cssnano](https://www.npmjs.com/package/cssnano) had issues - https://cssnano.github.io/cssnano/playground/ lite works, but i just couldn't get it to load through require, idk maybe im stupid
[ycssmin](https://www.npmjs.com/package/ycssmin) seemed a bit out of date
