### PR TITLE
Remade shouldSkipMinification() for Mac & Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Automatically minify your HTML, CSS, and JS files to optimize space and bandwidt
 
 - Automatically generates a `.min.html`, `.min.css`, or `.min.js` file each time you save a `.html`, `.css`, or `.js` file.
   For example: `styles.css` becomes `styles.min.css`.
+- Ability to generate min files only within a specified folder.
+- Cross-platform support (Windows, MacOS, Linux).
 
 ## Basic Usage
 

--- a/extension.js
+++ b/extension.js
@@ -213,11 +213,18 @@ function activate(context) {
 	}
 	
 	function shouldSkipMinification(fileName) {
-		const hasMinName = fileName.includes('.min.html') || fileName.includes('.min.js') || fileName.includes('.min.css'),
-			split = fileName.split("\\");
-		
-		// if "onlyMinUnderSubFolder" empty, just respond with hasMinName (original check), otherwise 
-		return onlyMinUnderSubFolder.length>0 && !hasMinName ? onlyMinUnderSubFolder.split(",").filter(folderName=>split.includes(folderName)).length===0 : hasMinName;
+		const parts = path.normalize(fileName).split(path.sep);
+		const baseName = path.basename(fileName);
+		const hasMinName = baseName.includes('.min.');
+		if(hasMinName) return true;
+		if(onlyMinUnderSubFolder.length > 0) {
+			const allowedFolders = onlyMinUnderSubFolder
+				.split(',')
+				.map(folder => folder.trim())
+				.filter(Boolean);
+			return !allowedFolders.some(folder => parts.includes(folder));
+		}
+		return false;
 	}
 
 	function getOutputFilePath(parentPath, fileName, extension, enableSeparateFolder) {


### PR DESCRIPTION
Added support for Mac and Linux based Operating systems by using `path.sep` instead of the hardcoded `\\` for path checks with the `shouldSkipMinification()` function. The path is also normalised as well to assist.

Tested on MacOS 26.4.1 (25E253) and on Ubuntu Desktop 24.